### PR TITLE
docs: add talkstream to open source repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Welcome! This repo is intended to highlight some awesome Dart Frog resources —
 ### Open source repos
 
 - [Flutter News Toolkit](https://github.com/flutter/news_toolkit): A news template application built in Flutter, by [Google](https://github.com/flutter) and [Very Good Ventures](https://github.com/VGVentures).
+- [Talk Stream](https://github.com/Yczar/talk-stream-backend): A chat application built using Flutter & Dart Frog, by [Yczar](https://github.com/Yczar).
 
 ### Apps
 


### PR DESCRIPTION
I added TalkStream, a chat app I created to the dart frog repository list.